### PR TITLE
Specify ContentType during file upload

### DIFF
--- a/Uploadcare.Tests/Uploaders/FileUploaderTest.cs
+++ b/Uploadcare.Tests/Uploaders/FileUploaderTest.cs
@@ -31,5 +31,5 @@ namespace Uploadcare.Tests.Uploaders
 
             Assert.NotNull(result.Uuid);
         }
-	}
+    }
 }

--- a/Uploadcare/Uploadcare.csproj
+++ b/Uploadcare/Uploadcare.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
If you upload an image without specifing the ContentType, it will be saved as octed-stream. It causes a lot of problem during image visualization by link (image will be downloaded).